### PR TITLE
Add before_save and after_save hooks

### DIFF
--- a/tests/Hooks/CopyImageHook.php
+++ b/tests/Hooks/CopyImageHook.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace QCod\ImageUp\Tests\Hooks;
+
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+
+class CopyImageHook
+{
+    public function handle($image)
+    {
+        Storage::disk('public')->put(
+            'uploads/copy_from_hook.jpg',
+            (string)$image->encode(null, 80),
+            'public'
+        );
+    }
+}

--- a/tests/Hooks/ResizeToFiftyHook.php
+++ b/tests/Hooks/ResizeToFiftyHook.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace QCod\ImageUp\Tests\Hooks;
+
+class ResizeToFiftyHook
+{
+    public function handle($image)
+    {
+        $image->resize(50, 50);
+    }
+}


### PR DESCRIPTION
Added the `before_save` and `after_save` hooks.
I'll be updating the documentation later.

This is the gist of the current PR

- Hooks can be a callback or class name. (The class should have a handle method)

- The intervention image is passed to the callback as an argument.

- The hooks are defined like this : 

```php
[
    'before_save' => 'Hooks\MyBeforeHook',
    'after_save' => function($image){
         // Do stuff
    }
]
```

- The class based hook is resolved through the ioc container, so any dependencies can be injected in the constructor.