### PR TITLE
Add tag 'config'

### DIFF
--- a/src/ImageUpServiceProvider.php
+++ b/src/ImageUpServiceProvider.php
@@ -15,7 +15,7 @@ class ImageUpServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/imageup.php' => config_path('imageup.php')
-        ]);
+        ], 'config');
 
         $this->mergeConfigFrom(
             __DIR__.'/../config/imageup.php',


### PR DESCRIPTION
In the documentation, the publish the configuration file command is not working because the 'config' tag is not defined.

```shel
php artisan vendor:publish --provider="QCod\ImageUp\ImageUpServiceProvider" --tag="config"
```

This small PR adds this tag.