### PR TITLE
Tests against more php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
+matrix:
+  include:
+    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
+  fast_finish: true
+  allow_failures:
+    - php: 7.3
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - phpenv config-rm xdebug.ini || return 0
+  - travis_retry composer self-update
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer install
+  - travis_retry composer install --no-interaction --no-suggest
 
 script: vendor/bin/phpunit --verbose
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=5.6.4",
     "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
     "intervention/image": "^2.4"
   },


### PR DESCRIPTION
Mentioned in #16.

Compatible with version **1.0.5** by commit https://github.com/qcod/laravel-imageup/commit/71b300c1249591a42cd46ac187b86248b5903052 (Nice work!)

- Tests on all versions supported by the package
- Turn off Xdebug & add cache directory ( speed up tests )
- Add composer flags on install script
- Update PHP constraint **>=5.6.4** ( required in [Laravel 5.4](https://github.com/laravel/framework/blob/8a74cf931b9df281707cef973ee9fba5b18793e8/composer.json#L18)   )