### PR TITLE
[Improvement] - Implements Handler interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,9 +337,9 @@ protected static $imageFields = [
     ]
 ];
 ```
+The hook class must implements `QCod\ImageUp\Contracts\Handler` interface, the `handle` method will be called when the hook is triggered.
 
-The hook class must have a method named `handle` that will be called when the hook is triggered.
-An instance of the intervention image will be passed to the `handle` method.
+*Note:* If the upload is an image, an instance of the intervention image will be passed to the `handle` method.
 
 ```php
 class BlurFilter {

--- a/src/Contracts/Handler.php
+++ b/src/Contracts/Handler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace QCod\ImageUp\Contracts;
+
+interface Handler
+{
+    public function handle($file);
+}

--- a/src/HasImageUploads.php
+++ b/src/HasImageUploads.php
@@ -2,6 +2,8 @@
 
 namespace QCod\ImageUp;
 
+use InvalidArgumentException;
+use QCod\ImageUp\Contracts\Handler;
 use Intervention\Image\Facades\Image;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Contracts\Validation\Factory;
@@ -671,9 +673,28 @@ trait HasImageUploads
 
         // We assume that the user is passing the hook class name
         if (is_string($hook)) {
-            $instance = app($hook);
+            $instance = $this->makeHook($hook);
             $instance->handle($image);
         }
+    }
+
+    /**
+     * Get the hook class instance.
+     *
+     * @param $hook
+     * @param $image
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function makeHook($hook)
+    {
+        $instance = app($hook);
+
+        if (! $instance instanceof Handler) {
+            throw new InvalidArgumentException("Class {$hook} must be an instance of QCod\\ImageUp\\Contracts\\Handler.");
+        }
+
+        return $instance;
     }
 
     /**

--- a/tests/Hooks/CopyImageHook.php
+++ b/tests/Hooks/CopyImageHook.php
@@ -3,9 +3,9 @@
 namespace QCod\ImageUp\Tests\Hooks;
 
 use Illuminate\Support\Facades\Storage;
-use Intervention\Image\Facades\Image;
+use QCod\ImageUp\Contracts\Handler;
 
-class CopyImageHook
+class CopyImageHook implements Handler
 {
     public function handle($image)
     {

--- a/tests/Hooks/HookWithoutInterface.php
+++ b/tests/Hooks/HookWithoutInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace QCod\ImageUp\Tests\Hooks;
+
+class HookWithoutInterface
+{
+    public function handle($file)
+    {
+        // do something...
+    }
+}

--- a/tests/Hooks/ResizeToFiftyHook.php
+++ b/tests/Hooks/ResizeToFiftyHook.php
@@ -2,7 +2,9 @@
 
 namespace QCod\ImageUp\Tests\Hooks;
 
-class ResizeToFiftyHook
+use QCod\ImageUp\Contracts\Handler;
+
+class ResizeToFiftyHook implements Handler
 {
     public function handle($image)
     {

--- a/tests/ImageUpTest.php
+++ b/tests/ImageUpTest.php
@@ -744,6 +744,28 @@ class ImageUpTest extends TestCase
         Storage::disk('public')->assertMissing('uploads/custome-avatar.jpg');
         $this->assertEquals('avatar/custome-avatar.jpg', $user->fresh()->getOriginal('avatar'));
     }
+
+    /**
+     * it expect exception from a hook class without handler interface.
+     *
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function it_expect_exception_from_a_hook_class_without_handler_interface()
+    {
+        $user = $this->createUser([], [
+            'avatar' => [
+                'width' => 100,
+                'height' => 100,
+                'before_save' => '\QCod\ImageUp\Tests\Hooks\HookWithoutInterface',
+            ]
+        ]);
+
+        Storage::fake('public');
+
+        $image = UploadedFile::fake()->image('avatar.jpg', 200, 200);
+        $user->uploadImage($image);
+    }
 }
 
 class CustomFilenameModel extends User {


### PR DESCRIPTION
## Description

In the documentation:

> The hook class must have a method named handle that will be called when the hook is triggered.

we can simply request that the interface be implemented in the hook class, to make the code more reliable.

## Motivation and context

Certify the implementation of the `handle` method in hook classes.

## Types of changes

- [x] **Breaking change!**
