### PR TITLE
Fixed an error when deleting a record

### DIFF
--- a/src/HasImageUploads.php
+++ b/src/HasImageUploads.php
@@ -797,7 +797,9 @@ trait HasImageUploads
         if (config('imageup.auto_delete_images')) {
             foreach ($this->getDefinedUploadFields() as $field => $options) {
                 $field = is_numeric($field) ? $options : $field;
-                $this->deleteImage($this->getOriginal($field));
+                if (!is_null($this->getOriginal($field))) {
+                    $this->deleteImage($this->getOriginal($field));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed an error when deleting a record if the icon field is null

TypeError: App\Models\User::deleteImage(): Argument #1 ($filePath) must be of type string, null given, called in /var/www/html/vendor/qcod/laravel-imageup/src/HasImageUploads.php on line 800 and defined in /var/www/html/vendor/qcod/laravel-imageup/src/HasImageUploads.php:64