### PR TITLE
return placeholder image if file not exists on storage

### DIFF
--- a/src/HasImageUploads.php
+++ b/src/HasImageUploads.php
@@ -106,7 +106,8 @@ trait HasImageUploads
         // check for placeholder defined in option
         $placeholderImage = Arr::get($this->uploadFieldOptions, 'placeholder');
 
-        return (empty($attributeValue) && $placeholderImage)
+        $exists = !empty($attributeValue) && $this->getStorageDisk()->exists($attributeValue);
+        return (!$exists && $placeholderImage)
             ? $placeholderImage
             : $this->getStorageDisk()->url($attributeValue);
     }

--- a/tests/ImageUpTest.php
+++ b/tests/ImageUpTest.php
@@ -207,11 +207,40 @@ class ImageUpTest extends TestCase
     }
 
     /**
-     * it gives image url if image saved in db
+     * it gives image url if image saved in db and file exists
      *
      * @test
      */
-    public function it_gives_image_url_if_image_saved_in_db()
+    public function it_gives_image_url_if_image_saved_in_db_and_file_exists()
+    {
+        $this->user = new User();
+        $this->user->setImagesField([
+            'avatar' => ['placeholder' => '/images/cover-placeholder.png']
+        ]);
+
+        $this->user->forceFill([
+            'name' => 'John',
+            'email' => 'John@email.com',
+            'password' => 'secret',
+            'avatar' => 'uploads/my-avatar.png'
+        ])->save();
+
+        Storage::fake('public');
+        $image = UploadedFile::fake()->image('my-avatar.png', 400, 500);
+        $this->user->uploadImage($image);
+
+        $this->assertEquals($this->user->getOriginal('avatar'), 'uploads/'.$image->hashName());
+
+        $this->assertEquals('/storage/uploads/' . $image->hashName(), $this->user->imageUrl());
+        $this->assertEquals('/storage/uploads/' . $image->hashName(), $this->user->imageUrl('avatar'));
+    }
+
+    /**
+     * it gives image url if image saved in db and file not exists
+     *
+     * @test
+     */
+    public function it_gives_placeholder_url_if_image_saved_in_db_and_file_not_exists()
     {
         $this->user = new User();
         $this->user->setImagesField([
@@ -227,8 +256,8 @@ class ImageUpTest extends TestCase
 
         $this->assertEquals($this->user->getOriginal('avatar'), 'uploads/my-avatar.png');
 
-        $this->assertEquals('/storage/uploads/my-avatar.png', $this->user->imageUrl());
-        $this->assertEquals('/storage/uploads/my-avatar.png', $this->user->imageUrl('avatar'));
+        $this->assertEquals('/images/cover-placeholder.png', $this->user->imageUrl());
+        $this->assertEquals('/images/cover-placeholder.png', $this->user->imageUrl('avatar'));
     }
 
     /**


### PR DESCRIPTION
sometimes the file is deleted or upload image failed and it will broken link when get image url when file is not exists. i added condition to check if file is exists and return placeholder image if file is missing instead broken image url.