### PR TITLE
Support a after upload hook on contained model scope

### DIFF
--- a/src/HasImageUploads.php
+++ b/src/HasImageUploads.php
@@ -164,7 +164,7 @@ trait HasImageUploads
      */
     public function getAfterUploadHook()
     {
-        return static::$afterUploadHook ?? $this->afterUploadHook;
+        return static::$uploadedHook ?? $this->afterUploadHook;
     }
 
     /**

--- a/src/HasImageUploads.php
+++ b/src/HasImageUploads.php
@@ -158,6 +158,14 @@ trait HasImageUploads
     {
         return static::$fileFields ?? $this->filesFields;
     }
+    /**
+     * Get after_upload hook defined on model
+     *
+     */
+    public function getAfterUploadHook()
+    {
+        return static::$afterUploadHook ?? $this->afterUploadHook;
+    }
 
     /**
      * Get upload field options
@@ -494,7 +502,7 @@ trait HasImageUploads
      */
     protected function triggerAfterUploadHook(): self
     {
-        $hook = $this->afterUploadHook;
+        $hook = $this->getAfterUploadHook();
         if (isset($hook)) {
             if (is_callable($hook)) {
                 $hook($this);


### PR DESCRIPTION
- provide hook class via `protected static $uploadedHook`
-  Hook class will be called via handle(Model $model) if any upload fields has been uploaded (ie, after autoupload call).